### PR TITLE
Bugfix subscriber-interface/fwd-service, should allow to select something else then it's self.

### DIFF
--- a/latest_sros_20.10/nokia-conf-svc-vprn-sub-if.yang
+++ b/latest_sros_20.10/nokia-conf-svc-vprn-sub-if.yang
@@ -88,7 +88,7 @@ submodule nokia-conf-svc-vprn-sub-if {
 
             leaf fwd-service {
                 type leafref {
-                    path "../../service-name";
+                    path "../../../vprn/service-name";
                 }
                 sros-ext:immutable;
                 description "Configure the forwarding service.";


### PR DESCRIPTION
It does not make sense to only allow to select you own service as fwd-service on a subscriber interface. Go up one more element to look among other vprn's also
